### PR TITLE
Add `KAKDecompostion` pass to `optimisation_level=2` after routing

### DIFF
--- a/pytket/extensions/pyquil/backends/forest.py
+++ b/pytket/extensions/pyquil/backends/forest.py
@@ -46,7 +46,7 @@ from pytket.passes import (
     EulerAngleReduction,
     CXMappingPass,
     auto_rebase_pass,
-    KAKDecomposition
+    KAKDecomposition,
     SequencePass,
     SynthesiseTket,
     DecomposeBoxes,
@@ -167,7 +167,9 @@ class ForestBackend(Backend):
         passlist.append(NaivePlacementPass(self.backend_info.architecture))  # type: ignore
         if optimisation_level == 2:
             # Add some connectivity preserving optimisations after routing.
-            passlist.extend([KAKDecomposition(allow_swaps=False), CliffordSimp(allow_swaps=False)])
+            passlist.extend(
+                [KAKDecomposition(allow_swaps=False), CliffordSimp(allow_swaps=False)]
+            )
         if optimisation_level > 0:
             passlist.append(SynthesiseTket())
         passlist.append(self.rebase_pass())

--- a/pytket/extensions/pyquil/backends/forest.py
+++ b/pytket/extensions/pyquil/backends/forest.py
@@ -167,7 +167,7 @@ class ForestBackend(Backend):
         passlist.append(NaivePlacementPass(self.backend_info.architecture))  # type: ignore
         if optimisation_level == 2:
             # Add some connectivity preserving optimisations after routing.
-            passlist.extend([KAKDecomposition(allow_swaps=False), CliffordSimp(False)])
+            passlist.extend([KAKDecomposition(allow_swaps=False), CliffordSimp(allow_swaps=False)])
         if optimisation_level > 0:
             passlist.append(SynthesiseTket())
         passlist.append(self.rebase_pass())

--- a/pytket/extensions/pyquil/backends/forest.py
+++ b/pytket/extensions/pyquil/backends/forest.py
@@ -46,6 +46,7 @@ from pytket.passes import (
     EulerAngleReduction,
     CXMappingPass,
     auto_rebase_pass,
+    KAKDecomposition
     SequencePass,
     SynthesiseTket,
     DecomposeBoxes,
@@ -165,7 +166,8 @@ class ForestBackend(Backend):
         )
         passlist.append(NaivePlacementPass(self.backend_info.architecture))  # type: ignore
         if optimisation_level == 2:
-            passlist.append(CliffordSimp(False))
+            # Add some connectivity preserving optimisations after routing.
+            passlist.extend([KAKDecomposition(allow_swaps=False), CliffordSimp(False)])
         if optimisation_level > 0:
             passlist.append(SynthesiseTket())
         passlist.append(self.rebase_pass())


### PR DESCRIPTION
Added a `KAKDecomposition` pass to `optimisation_level=2` for the `default_compilation_pass`. 

This is consistent with the passes applied by pytket-qiskit
https://tket.quantinuum.com/extensions/pytket-qiskit/#default-compilation

And pytket-iqm
https://github.com/CQCL/pytket-iqm/pull/78