### PR TITLE
Fix: Pin tenacity package version to 8.3.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 ~~~~~~~~~
 
+0.35.1 (June 2024)
+-------------------
+* Pin tenacity package version to 8.3.0.
+
 0.35.0 (April 2024)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "pytket ~= 1.27",
         "pyquil ~= 3.5",
         "typing-extensions ~= 4.2",
+        "tenacity == 8.3.0",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
# Description

Pinning the tenacity package version to 8.3.0 to get around the dependency issue here
https://github.com/jd/tenacity/issues/471

# Related issues

https://github.com/jd/tenacity/issues/471

