### PR TITLE
Release/0.40.0

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.39.0"
+__extension_version__ = "0.40.0"
 __extension_name__ = "pytket-pyquil"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@
 Changelog
 ~~~~~~~~~
 
-0.39.0 (unreleased)
+0.39.0 (March 2025)
 -------------------
 
 * Update pytket minimium version requirement to 2.0.1.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@
 Changelog
 ~~~~~~~~~
 
-0.39.0 (March 2025)
+0.40.0 (March 2025)
 -------------------
 
 * Update pytket minimium version requirement to 2.0.1.


### PR DESCRIPTION
# Description
There already was a version tag on the repo with a failed release.
I think it is best just to skip 0.39.0 and not mess up the tags on the repo.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
