### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
@@ -81,7 +81,7 @@ jobs:
       run: |
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+        poetry run pip install ../.
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,4 +2,23 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.pyquil
-    :members: pyquil_to_tk, tk_to_pyquil, ForestBackend, ForestStateBackend
+.. automodule:: pytket.extensions.pyquil._metadata
+.. automodule:: pytket.extensions.pyquil.pyquil_convert
+
+    .. autofunction:: pyquil_to_tk
+    .. autofunction:: tk_to_pyquil
+    .. autofunction:: param_from_pyquil
+    .. autofunction:: param_to_pyquil
+    .. autofunction:: process_characterisation
+    .. autofunction:: get_avg_characterisation
+
+.. automodule:: pytket.extensions.pyquil.backends
+.. automodule:: pytket.extensions.pyquil.backends.forest
+
+    .. autoclass:: ForestBackend
+        :members:
+    
+    .. autoclass:: ForestStateBackend
+        :members:
+    
+    .. autoexception:: PyQuilJobStatusUnavailable

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,7 +51,7 @@ Changelog
 ---------------------
 
 * Updated pytket version requirement to 1.23.
-* Don’t include :py:class:`SimplifyInitial` in default passes; instead make it an option to ``process_circuits()``.
+* Don’t include :py:meth:`pytket.passes.SimplifyInitial` in default passes; instead make it an option to ``process_circuits()``.
 
 0.31.0 (November 2023)
 ----------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,7 @@ Changelog
 --------------------
 
 * Update pytket version requirement to 1.31.
-* add CH and CY to the supported gateset.
+* Add CH and CY to the supported gateset.
 
 0.36.0 (July 2024)
 ------------------
@@ -51,13 +51,13 @@ Changelog
 ---------------------
 
 * Updated pytket version requirement to 1.23.
-* Don’t include :py:meth:`pytket.passes.SimplifyInitial` in default passes; instead make it an option to ``process_circuits()``.
+* Don’t include :py:meth:`pytket.passes.SimplifyInitial` in default passes; instead make it an option to :py:meth:`~pytket.backends.backend.Backend.process_circuits`.
 
 0.31.0 (November 2023)
 ----------------------
 
 * Updated pytket version requirement to 1.22.
-* add pyquil.gates.XY to the native gateset
+* Add pyquil.gates.XY to the native gateset
 
 0.30.0 (October 2023)
 ---------------------
@@ -76,7 +76,7 @@ Changelog
 
 * Updated pytket version requirement to 1.9.
 * Change default optimization level in
-  ``default_compilation_pass()`` to 2.
+  :py:meth:`~pytket.backends.backend.Backend.default_compilation_pass` to 2.
 
 0.27.0 (October 2022)
 ---------------------
@@ -133,7 +133,7 @@ Changelog
 0.17.0 (October 2021)
 ---------------------
 
-* Modify `ForestBackend` constructor to accept a `QuantumComputer`.
+* Modify :py:class:`~.ForestBackend` constructor to accept a :py:class:`pyquil.api.QuantumComputer`.
 * Updated pytket version requirement to 0.16.
 
 0.16.0 (September 2021)

--- a/pytket/extensions/pyquil/__init__.py
+++ b/pytket/extensions/pyquil/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for conversion between Rigetti pyQuil and tket primitives."""
 
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__

--- a/pytket/extensions/pyquil/backends/__init__.py
+++ b/pytket/extensions/pyquil/backends/__init__.py
@@ -12,9 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Backends for connecting to devices and simulators from the Rigetti Forest platform
-directly from pytket
-"""
-
 from .forest import ForestBackend, ForestStateBackend

--- a/pytket/extensions/pyquil/backends/forest.py
+++ b/pytket/extensions/pyquil/backends/forest.py
@@ -197,7 +197,7 @@ class ForestBackend(Backend):
         * `seed`
         * `postprocess`: apply end-of-circuit simplifications and classical
           postprocessing to improve fidelity of results (bool, default False)
-        * `simplify_initial`: apply the pytket ``SimplifyInitial`` pass to improve
+        * `simplify_initial`: apply the pytket :py:meth:`~pytket.passes.SimplifyInitial` pass to improve
           fidelity of results assuming all qubits initialized to zero (bool, default
           False)
         """
@@ -252,10 +252,10 @@ class ForestBackend(Backend):
 
     def circuit_status(self, handle: ResultHandle) -> CircuitStatus:
         """
-        Return a CircuitStatus reporting the status of the circuit execution
-        corresponding to the ResultHandle.
+        Return a :py:class:`~pytket.backends.status.CircuitStatus` reporting the status of the circuit execution
+        corresponding to the :py:class:`~pytket.backends.resulthandle.ResultHandle`.
 
-        This will throw an PyQuilJobStatusUnavailable exception if the results
+        This will throw an :py:exc:`~.PyQuilJobStatusUnavailable` exception if the results
         have not been retrieved yet, as pyQuil does not currently support asynchronous
         job status queries.
 

--- a/pytket/extensions/pyquil/backends/forest.py
+++ b/pytket/extensions/pyquil/backends/forest.py
@@ -123,7 +123,6 @@ class ForestBackend(Backend):
 
         :param qc: The particular QuantumComputer to use. See the pyQuil docs for more
         details.
-        :type qc: QuantumComputer
         """
         super().__init__()
         self._qc: QuantumComputer = qc
@@ -191,7 +190,7 @@ class ForestBackend(Backend):
         **kwargs: KwargTypes,
     ) -> list[ResultHandle]:
         """
-        See :py:meth:`pytket.backends.Backend.process_circuits`.
+        See :py:meth:`pytket.backends.backend.Backend.process_circuits`.
 
         Supported kwargs:
 
@@ -261,10 +260,9 @@ class ForestBackend(Backend):
         job status queries.
 
         :param handle: The handle to the submitted job.
-        :type handle: ResultHandle
         :returns: The status of the submitted job.
         :raises PyQuilJobStatusUnavailable: Cannot retrieve job status.
-        :raises CircuitNotRunError: The handle does not correspond to a valid job.
+        :raises pytket.backends.backend_exceptions.CircuitNotRunError: The handle does not correspond to a valid job.
         """
         if handle in self._cache and "result" in self._cache[handle]:
             return CircuitStatus(StatusEnum.COMPLETED)
@@ -276,7 +274,7 @@ class ForestBackend(Backend):
 
     def get_result(self, handle: ResultHandle, **kwargs: KwargTypes) -> BackendResult:
         """
-        See :py:meth:`pytket.backends.Backend.get_result`.
+        See :py:meth:`pytket.backends.backend.Backend.get_result`.
         Supported kwargs: none.
         """
         try:
@@ -325,7 +323,7 @@ class ForestBackend(Backend):
     @classmethod
     def available_devices(cls, **kwargs: Any) -> list[BackendInfo]:
         """
-        See :py:meth:`pytket.backends.Backend.available_devices`.
+        See :py:meth:`pytket.backends.backend.Backend.available_devices`.
 
         Supported kwargs:
 
@@ -459,11 +457,8 @@ class ForestStateBackend(Backend):
 
         :param state_circuit: Circuit that generates the desired state
             :math:`\\left|\\psi\\right>`.
-        :type state_circuit: Circuit
         :param pauli: Pauli operator
-        :type pauli: QubitPauliString
         :return: :math:`\\left<\\psi | P | \\psi \\right>`
-        :rtype: complex
         """
         prog = tk_to_pyquil(state_circuit)
         pauli_term = self._gen_PauliTerm(pauli)
@@ -477,11 +472,8 @@ class ForestStateBackend(Backend):
 
         :param state_circuit: Circuit that generates the desired state
             :math:`\\left|\\psi\\right>`.
-        :type state_circuit: Circuit
         :param operator: Operator :math:`H`.
-        :type operator: QubitPauliOperator
         :return: :math:`\\left<\\psi | H | \\psi \\right>`
-        :rtype: complex
         """
         prog = tk_to_pyquil(state_circuit)
         pauli_sum = PauliSum(

--- a/pytket/extensions/pyquil/pyquil_convert.py
+++ b/pytket/extensions/pyquil/pyquil_convert.py
@@ -166,7 +166,7 @@ def param_from_pyquil(p: float | Expression) -> Expr:
 
 def pyquil_to_tk(prog: Program) -> Circuit:
     """
-    Convert a :py:class:`pyquil.Program` to a tket :py:class:`Circuit` .
+    Convert a :py:class:`pyquil.Program` to a tket :py:class:`~pytket._tket.circuit.Circuit` .
     Note that not all pyQuil operations are currently supported by pytket.
 
     :param prog: A circuit to be converted
@@ -237,7 +237,7 @@ def tk_to_pyquil(  # noqa: PLR0912, PLR0915
     tkcirc: Circuit, active_reset: bool = False, return_used_bits: bool = False
 ) -> Program | tuple[Program, list[Bit]]:
     """
-       Convert a tket :py:class:`Circuit` to a :py:class:`pyquil.Program` .
+       Convert a tket :py:class:`~pytket._tket.circuit.Circuit` to a :py:class:`pyquil.Program` .
 
     :param tkcirc: A circuit to be converted
 
@@ -327,7 +327,6 @@ def process_characterisation(qc: QuantumComputer) -> dict:  # noqa: PLR0912, PLR
     Rigetti device Characteristics
 
     :param qc: A quantum computer to be converted
-    :type qc: QuantumComputer
     :return: A dictionary containing Rigetti device characteristics
     """
     isa = qc.quantum_processor.to_compiler_isa()

--- a/pytket/extensions/pyquil/pyquil_convert.py
+++ b/pytket/extensions/pyquil/pyquil_convert.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Methods to allow conversion between pyQuil and tket data types"""
-
 import math
 from collections import defaultdict
 from collections.abc import Callable
@@ -237,7 +235,7 @@ def tk_to_pyquil(  # noqa: PLR0912, PLR0915
     tkcirc: Circuit, active_reset: bool = False, return_used_bits: bool = False
 ) -> Program | tuple[Program, list[Bit]]:
     """
-       Convert a tket :py:class:`~pytket._tket.circuit.Circuit` to a :py:class:`pyquil.Program` .
+    Convert a tket :py:class:`~pytket._tket.circuit.Circuit` to a :py:class:`pyquil.Program` .
 
     :param tkcirc: A circuit to be converted
 
@@ -324,7 +322,7 @@ def tk_to_pyquil(  # noqa: PLR0912, PLR0915
 
 def process_characterisation(qc: QuantumComputer) -> dict:  # noqa: PLR0912, PLR0915
     """Convert a :py:class:`pyquil.api.QuantumComputer` to a dictionary containing
-    Rigetti device Characteristics
+    Rigetti device characteristics
 
     :param qc: A quantum computer to be converted
     :return: A dictionary containing Rigetti device characteristics
@@ -441,8 +439,8 @@ def get_avg_characterisation(
     """
     Convert gate-specific characterisation into readout, one- and two-qubit errors
 
-    Used to convert a typical output from `process_characterisation` into an input
-    noise characterisation for NoiseAwarePlacement
+    Used to convert a typical output from :py:func:`~.process_characterisation` into an input
+    noise characterisation for :py:class:`~pytket.placement.NoiseAwarePlacement`
     """
 
     K = TypeVar("K")


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
